### PR TITLE
CGI->cgi

### DIFF
--- a/lib/rgigya.rb
+++ b/lib/rgigya.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'httparty'
-require 'CGI'
+require 'cgi'
 require File.dirname(__FILE__)+"/rgigya/base.rb"
 require File.dirname(__FILE__)+"/rgigya/sig_utils.rb"
 require File.dirname(__FILE__)+"/rgigya/hash.rb"


### PR DESCRIPTION
We went to deploy an app using this gem to elasticbeanstalk and were coming up with an issue with the require statement `require 'CGI`. Turns out it should be `require 'cgi'`.
